### PR TITLE
Implement fine-grained control of bg module load delay

### DIFF
--- a/lazyasd-py2.py
+++ b/lazyasd-py2.py
@@ -291,32 +291,107 @@ class BackgroundModuleProxy(types.ModuleType):
             time.sleep(0.001)
         return getattr(mod, name)
 
+class BackgroundModuleDelay:
+    def __init__(self):
+        pass
 
-class BackgroundModuleLoader(threading.Thread):
-    """Thread to load modules in the background."""
+    def wait(self):
+        pass
 
-    def __init__(self, name, package, replacements, *args, **kwargs):
-        super(BackgroundModuleLoader, self).__init__(*args, **kwargs)
-        self.daemon = True
-        self.name = name
-        self.package = package
-        self.replacements = replacements
-        self.start()
+class BackgroundModuleDelayDefault(BackgroundModuleDelay):
+    # wait for other modules to stop being imported
+    # We assume that module loading is finished when sys.modules doesn't
+    # get longer in numchecks consecutive checkperiodms  waiting steps
+    # default 5 checks with 1ms interval
+    def __init__(self, numchecks=5, checkperiodms=1):
+        self.numchecks = numchecks
+        self.checkperiodms = checkperiodms
 
-    def run(self):
-        # wait for other modules to stop being imported
-        # We assume that module loading is finished when sys.modules doesn't
-        # get longer in 5 consecutive 1ms waiting steps
+    def wait(self):
+        _numchecks = self.numchecks
+        _checkperiodms = self.checkperiodms
         counter = 0
         last = -1
-        while counter < 5:
+        while counter < _numchecks:
             new = len(sys.modules)
             if new == last:
                 counter += 1
             else:
                 last = new
                 counter = 0
-            time.sleep(0.001)
+            
+            time.sleep(0.001 * _checkperiodms)
+
+class BackgroundModuleDelayExpBackoff(BackgroundModuleDelay):
+    # Require numchecks consecutive periods where
+    # sys.modules doesn't grow. Increase check interval
+    # starting with initicheckperiodms on each check by
+    # factor. Gives exponential back-off behvaiour.
+    def __init__(self, numchecks=5, initcheckperiodms=1, factor=2):
+        self.numchecks = numchecks
+        self.initcheckperiodms = initcheckperiodms
+        self.factor = factor
+
+    def wait(self):
+        _numchecks = self.numchecks
+        _factor = self.factor
+        _checkperiodms = self.initcheckperiodms
+
+        counter = 0
+        last = -1
+        while counter < _numchecks:
+            new = len(sys.modules)
+            if new == last:
+                counter += 1
+            else:
+                last = new
+                counter = 0
+        _checkperiodms = _checkperiodms * _factor;    
+        time.sleep(0.001 * _checkperiodms)
+
+class BackgroundModuleDelayNoop(BackgroundModuleDelay):
+    # Do not wait, at all
+    def __init__(self):
+        pass
+    def wait(self):
+        pass
+
+class BackgroundModuleDelayConst(BackgroundModuleDelay):
+    # Wait a constant delayms milliseconds
+    def __init__(self, delayms):
+        self.delayms = delayms
+    def wait(self):
+        time.sleep(0.001 * self.delayms)
+
+class BackgroundModuleDelayEvent(BackgroundModuleDelay):
+    # Wait until main thread tells us to proceed
+    def __init__(self, timeoutms):
+        self.timeoutms = timeoutms
+
+    def get_event(self):
+        self.event = threading.Event()
+        return self.event
+
+    def wait(self):
+        _timeoutms = self.timeoutms
+        while not self.event.wait(0.001 * self.timeoutms):
+            pass
+
+class BackgroundModuleLoader(threading.Thread):
+    """Thread to load modules in the background."""
+
+    def __init__(self, name, package, replacements,\
+            delayobj=BackgroundModuleDelayDefault(), *args, **kwargs):
+        super(BackgroundModuleLoader, self).__init__(*args, **kwargs)
+        self.daemon = True
+        self.name = name
+        self.package = package
+        self.replacements = replacements
+        self.delayobj = delayobj
+        self.start()
+
+    def run(self):
+        self.delayobj.wait()
         # now import module properly
         modname = resolve_name(self.name, self.package)
         if isinstance(sys.modules[modname], BackgroundModuleProxy):
@@ -329,7 +404,7 @@ class BackgroundModuleLoader(threading.Thread):
 
 
 def load_module_in_background(name, package=None, debug='DEBUG', env=None,
-                              replacements=None):
+                              replacements=None, delayobj=BackgroundModuleDelayDefault()):
     """Entry point for loading modules in background thread.
 
     Parameters
@@ -348,6 +423,10 @@ def load_module_in_background(name, package=None, debug='DEBUG', env=None,
         import the lazily loaded moudle, with the variable name in that
         module. For example, suppose that foo.bar imports module a as b,
         this dict is then {'foo.bar': 'b'}.
+    delayobj: initial delay before loading module
+        default(None): until sys.modules stops growing for 5ms.
+            Other options include Noop (do not wait), ExpBackoff (exponential
+            backoff), and Const (constant delay).
 
     Returns
     -------
@@ -369,5 +448,5 @@ def load_module_in_background(name, package=None, debug='DEBUG', env=None,
         mod = importlib.import_module(name, package=package)
         return mod
     proxy = sys.modules[modname] = BackgroundModuleProxy(modname)
-    BackgroundModuleLoader(name, package, replacements or {})
+    BackgroundModuleLoader(name, package, replacements or {}, delayobj)
     return proxy

--- a/tests/test_lazyasd.py
+++ b/tests/test_lazyasd.py
@@ -1,5 +1,7 @@
 """Tests lazy and self destruictive objects."""
-from lazyasd import LazyObject, load_module_in_background
+from lazyasd import LazyObject, load_module_in_background,\
+        BackgroundModuleDelayNoop, BackgroundModuleDelayExpBackoff,\
+        BackgroundModuleDelayConst, BackgroundModuleDelayEvent
 
 #
 # LazyObject Tests
@@ -12,5 +14,28 @@ def test_lazyobject_getitem():
 
 def test_bg_load():
     load_module_in_background('pkg_resources')
+    import pkg_resources
+    pkg_resources.iter_entry_points
+
+def test_bg_load_delay_noop():
+    load_module_in_background('pkg_resources', delayobj=BackgroundModuleDelayNoop())
+    import pkg_resources
+    pkg_resources.iter_entry_points
+
+def test_bg_load_delay_expbackoff():
+    load_module_in_background('pkg_resources', delayobj=BackgroundModuleDelayExpBackoff(5, 1, 2))
+    import pkg_resources
+    pkg_resources.iter_entry_points
+
+def test_bg_load_delay_const():
+    load_module_in_background('pkg_resources', delayobj=BackgroundModuleDelayConst(50))
+    import pkg_resources
+    pkg_resources.iter_entry_points
+
+def test_bg_load_delay_event():
+    delayobj=BackgroundModuleDelayEvent(50)
+    ev = delayobj.get_event()
+    load_module_in_background('pkg_resources', delayobj=delayobj)
+    ev.set()
     import pkg_resources
     pkg_resources.iter_entry_points


### PR DESCRIPTION
The background module loader delays before importing the given module. Currently, it does this in one particular way - check len(sys.modules) and proceed only when it stops growing. The parameters it uses to do so are hardcoded.

I have implemented parametrization for this functionality. Caller can now pass in an object with a wait() interface. The existing method is still the default complete with its previously hardcoded parameters, although they can now be changed at call-time. Additional delay implementations have been added:
* Noop (no wait)
* Exponential back-off
* Constant time delay
* Block on threading.Event
I've added the comments and unit tests for all of them.

My particular use case involves needing to avoid time.sleep() there (the Noop case), because it triggers a deadlock when running tests under nose. However, I think the others might be useful to others.

To be clear: the default path has not functionally changed and all unit tests pass.