### PR TITLE
Don't install LICENSE, README, or lazyasd-py[23] files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include LICENSE
 include README.rst
+include lazyasd-py*.py

--- a/setup.py
+++ b/setup.py
@@ -38,8 +38,6 @@ setup_kwargs = {
         "Topic :: Utilities",
         ],
     "zip_safe": False,
-    "data_files": [("", ['LICENSE', 'README.rst',
-                         'lazyasd-py2.py', 'lazyasd-py3.py']),],
     }
 
 


### PR DESCRIPTION
I believe the intent was to include these in the sdist, but not install them. The way to do this is with `MANIFEST.in` ([docs](https://setuptools.readthedocs.io/en/latest/deprecated/distutils/sourcedist.html#specifying-the-files-to-distribute)).

Closes #10